### PR TITLE
Improve entry persistence and settings flow

### DIFF
--- a/rss-desktop/src/stores/feedStore.ts
+++ b/rss-desktop/src/stores/feedStore.ts
@@ -2,8 +2,10 @@ import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import api from '../api/client'
 import type { Entry, Feed, SummaryResult, TranslationResult } from '../types'
+import { useSettingsStore } from './settingsStore'
 
 export const useFeedStore = defineStore('feed', () => {
+  const settingsStore = useSettingsStore()
   const feeds = ref<Feed[]>([])
   const entries = ref<Entry[]>([])
   const activeFeedId = ref<string | null>(null)
@@ -215,7 +217,13 @@ export const useFeedStore = defineStore('feed', () => {
       }
       lastEntryFilters.value = mergedFilters
 
-      const params: Record<string, string | number | boolean> = { limit: 100 }
+      const resolveLimit = () => {
+        const value = settingsStore.settings.items_per_page
+        if (!value || Number.isNaN(value)) return 50
+        return Math.min(Math.max(value, 1), 200)
+      }
+
+      const params: Record<string, string | number | boolean> = { limit: resolveLimit() }
 
       // 优先使用 feedId，其次使用 groupName
       if (targetFeed) {

--- a/rss-desktop/src/stores/settingsStore.ts
+++ b/rss-desktop/src/stores/settingsStore.ts
@@ -4,6 +4,7 @@ import api from '../api/client'
 
 export interface AppSettings {
   fetch_interval_minutes: number
+  items_per_page: number
   // 时间过滤相关设置
   enable_date_filter: boolean
   default_date_range: string
@@ -14,6 +15,7 @@ export interface AppSettings {
 export const useSettingsStore = defineStore('settings', () => {
   const settings = ref<AppSettings>({
     fetch_interval_minutes: 15,
+    items_per_page: 50,
     enable_date_filter: true,
     default_date_range: '30d',
     time_field: 'inserted_at',


### PR DESCRIPTION
## Summary
- batch existing-entry lookups during feed refreshes and ensure RSSHub cache is invalidated when mirrors are modified
- honor the user’s `items_per_page` preference for entry queries and expose that value to the desktop app
- let the settings modal stage display/refresh options locally, make the auto-refresh toggle functional, and persist all display settings in a single save action

## Testing
- ⚠️ `pytest` *(fails: async test helpers require an additional pytest plugin)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69192d881fbc8333b0219f946b1a4990)