### PR TITLE
Fix RSSHub priority query and add regression test

### DIFF
--- a/backend/app/services/rsshub_manager.py
+++ b/backend/app/services/rsshub_manager.py
@@ -77,7 +77,9 @@ class RSSHubManager:
             # 创建新镜像
             if priority is None:
                 # 自动分配最低优先级
-                max_priority = session.exec(select(RSSHubConfig)).order_by(RSSHubConfig.priority.desc()).first()
+                max_priority = session.exec(
+                    select(RSSHubConfig).order_by(RSSHubConfig.priority.desc())
+                ).first()
                 priority = (max_priority.priority + 1) if max_priority else 1
 
             mirror = RSSHubConfig(

--- a/backend/tests/test_rsshub_manager.py
+++ b/backend/tests/test_rsshub_manager.py
@@ -1,0 +1,49 @@
+import asyncio
+import importlib
+import sys
+from pathlib import Path
+
+from sqlmodel import select
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+
+def test_priority_auto_increment(monkeypatch, tmp_path):
+    monkeypatch.setenv("AURORA_DATA_DIR", str(tmp_path))
+
+    from app.core import config as config_module
+    importlib.reload(config_module)
+
+    from app.models import rsshub_config as rsshub_config_module
+
+    from app.db import session as session_module
+    importlib.reload(session_module)
+    session_module.init_db()
+
+    from app.services import rsshub_manager as manager_module
+    importlib.reload(manager_module)
+
+    manager = manager_module.RSSHubManager()
+
+    asyncio.run(
+        manager.add_mirror(name="Mirror A", base_url="https://a.example.com", priority=None)
+    )
+    asyncio.run(
+        manager.add_mirror(name="Mirror B", base_url="https://b.example.com", priority=None)
+    )
+
+    with session_module.SessionLocal() as session:
+        mirrors = session.exec(
+            select(rsshub_config_module.RSSHubConfig).order_by(
+                rsshub_config_module.RSSHubConfig.priority
+            )
+        ).all()
+
+    assert [mirror.priority for mirror in mirrors] == [1, 2]
+    assert [mirror.base_url for mirror in mirrors] == [
+        "https://a.example.com",
+        "https://b.example.com",
+    ]


### PR DESCRIPTION
## Summary
- fix `RSSHubManager.add_mirror` to execute the priority query with an ordered `select` statement so the highest priority row is correctly retrieved
- add a regression test that verifies auto-assigned priorities increment sequentially when none are provided

## Testing
- `cd backend && pytest tests/test_rsshub_manager.py -k priority`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691953a58e788333a07a73a8e0c4fc3b)