### PR TITLE
Ensure user settings schema is patched

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,6 +15,7 @@ from app.services.rsshub_manager import rsshub_manager
 from app.core.config import settings, APP_DATA_DIR
 from app.db.session import init_db
 from app.services.fetcher import refresh_all_feeds
+from app.services.user_settings_service import ensure_user_settings_schema
 
 # 允许所有localhost端口访问
 import re
@@ -63,6 +64,7 @@ def build_allowed_origins() -> list[str]:
 @asynccontextmanager
 async def lifespan(_: FastAPI):
     init_db()
+    ensure_user_settings_schema()
     # 初始化RSSHub配置
     await rsshub_manager.initialize_default_mirrors()
 

--- a/backend/tests/test_user_settings_schema.py
+++ b/backend/tests/test_user_settings_schema.py
@@ -1,0 +1,60 @@
+import sqlite3
+
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import Session, create_engine
+
+from app.services import user_settings_service as service_module
+from app.services.user_settings_service import UserSettingsService
+
+
+def test_get_settings_backfills_missing_columns(tmp_path):
+    """Legacy databases missing new columns should be patched on demand."""
+    legacy_db = tmp_path / "legacy.sqlite"
+
+    with sqlite3.connect(legacy_db) as conn:
+        conn.execute(
+            """
+            CREATE TABLE user_settings (
+                id INTEGER PRIMARY KEY,
+                rsshub_url TEXT DEFAULT 'https://rsshub.app',
+                fetch_interval_minutes INTEGER DEFAULT 720,
+                auto_refresh BOOLEAN DEFAULT 1,
+                show_description BOOLEAN DEFAULT 1,
+                items_per_page INTEGER DEFAULT 50,
+                created_at TIMESTAMP,
+                updated_at TIMESTAMP
+            )
+            """
+        )
+        conn.commit()
+
+    test_engine = create_engine(
+        f"sqlite:///{legacy_db}",
+        connect_args={"check_same_thread": False},
+    )
+    test_session_local = sessionmaker(
+        autocommit=False,
+        autoflush=False,
+        bind=test_engine,
+        class_=Session,
+    )
+
+    original_engine = service_module.engine
+    original_session_local = service_module.SessionLocal
+    original_schema_checked = service_module._schema_checked
+
+    try:
+        service_module.engine = test_engine
+        service_module.SessionLocal = test_session_local
+        service_module._schema_checked = False
+
+        settings = UserSettingsService.get_settings()
+
+        assert settings.show_entry_summary is True
+        assert settings.enable_date_filter is True
+        assert settings.default_date_range == "30d"
+        assert settings.time_field == "inserted_at"
+    finally:
+        service_module.engine = original_engine
+        service_module.SessionLocal = original_session_local
+        service_module._schema_checked = original_schema_checked


### PR DESCRIPTION
## Summary
- ensure all user settings columns are added automatically and run the schema guard during startup
- add coverage that verifies legacy SQLite databases are upgraded before settings are loaded

## Testing
- pytest *(fails: existing scripts/test_translation.py tests require an async plugin)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691953a77f408333949a2fc89d2c410a)