### PR TITLE
Centralize RSSHub default mirror configuration

### DIFF
--- a/backend/app/models/rsshub_config.py
+++ b/backend/app/models/rsshub_config.py
@@ -5,6 +5,8 @@ from typing import Optional
 from sqlmodel import SQLModel, Field
 from datetime import datetime
 
+from app.services.rsshub_defaults import get_default_rsshub_mirrors
+
 
 class RSSHubConfig(SQLModel, table=True):
     """RSSHub镜像配置"""
@@ -42,30 +44,4 @@ class RSSHubURLMapping(SQLModel, table=True):
 
 
 # RSSHub镜像预设配置
-DEFAULT_RSSHUB_MIRRORS = [
-    {
-        "name": "主镜像 (官方)",
-        "base_url": "https://rsshub.app",
-        "priority": 1,
-        "is_default": True,
-        "description": "RSSHub官方镜像"
-    },
-    {
-        "name": "备用镜像1",
-        "base_url": "https://rsshub.rssforever.com",
-        "priority": 2,
-        "description": "RSSHub备用镜像1"
-    },
-    {
-        "name": "备用镜像2",
-        "base_url": "https://rsshub.ktachibana.party",
-        "priority": 3,
-        "description": "RSSHub备用镜像2"
-    },
-    {
-        "name": "备用镜像3",
-        "base_url": "https://rsshub.cskaoyan.com",
-        "priority": 4,
-        "description": "RSSHub备用镜像3"
-    }
-]
+DEFAULT_RSSHUB_MIRRORS = get_default_rsshub_mirrors()

--- a/backend/app/services/feed_config.py
+++ b/backend/app/services/feed_config.py
@@ -2,13 +2,11 @@
 RSS源的特殊配置和处理规则
 """
 
+from app.services.rsshub_defaults import get_default_rsshub_base_urls
+
+
 # RSSHub备用镜像配置 (作为备用，主要使用动态配置)
-DEFAULT_RSSHUB_MIRRORS = [
-    'https://rsshub.app',
-    'https://rsshub.rssforever.com',
-    'https://rsshub.ktachibana.party',
-    'https://rsshub.cskaoyan.com'
-]
+DEFAULT_RSSHUB_MIRRORS = get_default_rsshub_base_urls()
 
 # 动态获取RSSHub镜像的函数
 async def get_rsshub_mirrors():
@@ -19,7 +17,7 @@ async def get_rsshub_mirrors():
         return [mirror.base_url for mirror in mirrors]
     except Exception:
         # 如果动态获取失败，使用默认配置
-        return DEFAULT_RSSHUB_MIRRORS
+        return get_default_rsshub_base_urls()
 
 # 需要特殊User-Agent的域名
 SPECIAL_USER_AGENTS = {

--- a/backend/app/services/rsshub_defaults.py
+++ b/backend/app/services/rsshub_defaults.py
@@ -1,0 +1,49 @@
+"""Default RSSHub mirror configuration helpers."""
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Dict, List
+
+
+_DEFAULT_RSSHUB_MIRRORS: List[Dict[str, object]] = [
+    {
+        "name": "主镜像 (官方)",
+        "base_url": "https://rsshub.app",
+        "priority": 1,
+        "is_default": True,
+        "description": "RSSHub官方镜像",
+    },
+    {
+        "name": "备用镜像1",
+        "base_url": "https://rsshub.rssforever.com",
+        "priority": 2,
+        "description": "RSSHub备用镜像1",
+    },
+    {
+        "name": "备用镜像2",
+        "base_url": "https://rsshub.ktachibana.party",
+        "priority": 3,
+        "description": "RSSHub备用镜像2",
+    },
+    {
+        "name": "备用镜像3",
+        "base_url": "https://rsshub.cskaoyan.com",
+        "priority": 4,
+        "description": "RSSHub备用镜像3",
+    },
+]
+
+
+def get_default_rsshub_mirrors() -> List[Dict[str, object]]:
+    """Return a deep copy of the structured default mirror definitions."""
+    return deepcopy(_DEFAULT_RSSHUB_MIRRORS)
+
+
+def get_default_rsshub_base_urls() -> List[str]:
+    """Return the base URLs from the default mirror definitions."""
+    return [mirror["base_url"] for mirror in _DEFAULT_RSSHUB_MIRRORS]
+
+
+# Backwards-compatible exports for modules that still expect constants
+DEFAULT_RSSHUB_MIRRORS = get_default_rsshub_mirrors()
+DEFAULT_RSSHUB_BASE_URLS = get_default_rsshub_base_urls()

--- a/backend/app/services/rsshub_manager.py
+++ b/backend/app/services/rsshub_manager.py
@@ -5,7 +5,8 @@ import asyncio
 from typing import List, Optional
 from sqlmodel import Session, select
 from app.db.session import SessionLocal
-from app.models.rsshub_config import RSSHubConfig, RSSHubURLMapping, DEFAULT_RSSHUB_MIRRORS
+from app.models.rsshub_config import RSSHubConfig, RSSHubURLMapping
+from app.services.rsshub_defaults import get_default_rsshub_mirrors
 
 
 class RSSHubManager:
@@ -202,7 +203,7 @@ class RSSHubManager:
         with SessionLocal() as session:
             existing_mirrors = session.exec(select(RSSHubConfig)).all()
             if len(existing_mirrors) == 0:
-                for mirror_data in DEFAULT_RSSHUB_MIRRORS:
+                for mirror_data in get_default_rsshub_mirrors():
                     mirror = RSSHubConfig(**mirror_data)
                     session.add(mirror)
                 session.commit()


### PR DESCRIPTION
## Summary
- add a dedicated `rsshub_defaults` service module that owns the structured list of default RSSHub mirrors and provides helper functions for consumers
- update the feed configuration fallback, RSSHub config model defaults, and the RSSHub manager initialization logic to source data from the shared module

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691953b2174083339334d08fa478531c)